### PR TITLE
Implement basic ThreadPool resizing

### DIFF
--- a/third_party/xla/xla/tsl/platform/threadpool.cc
+++ b/third_party/xla/xla/tsl/platform/threadpool.cc
@@ -122,6 +122,12 @@ ThreadPool::ThreadPool(Env* env, const ThreadOptions& thread_options,
                        bool low_latency_hint, Eigen::Allocator* allocator) {
   CHECK_GE(num_threads, 1);
 
+  env_ = env;
+  thread_options_ = thread_options;
+  name_ = name;
+  low_latency_hint_ = low_latency_hint;
+  allocator_ = allocator;
+
 #ifdef DNNL_AARCH64_USE_ACL
   // To avoid cost of swapping in and out threads from running processes
   // we do not use all available cores to parallelise TF operations.
@@ -145,6 +151,11 @@ ThreadPool::ThreadPool(Env* env, const ThreadOptions& thread_options,
 }
 
 ThreadPool::ThreadPool(thread::ThreadPoolInterface* user_threadpool) {
+  env_ = nullptr;
+  name_.clear();
+  low_latency_hint_ = true;
+  thread_options_ = ThreadOptions();
+  allocator_ = nullptr;
   underlying_threadpool_ = user_threadpool;
   threadpool_device_.reset(new Eigen::ThreadPoolDevice(
       underlying_threadpool_, underlying_threadpool_->NumThreads(), nullptr));
@@ -272,6 +283,17 @@ int ThreadPool::CurrentThreadId() const {
 void ThreadPool::ScheduleWithHint(std::function<void()> fn, int start,
                                   int limit) {
   underlying_threadpool_->ScheduleWithHint(std::move(fn), start, limit);
+}
+
+void ThreadPool::Resize(int num_threads) {
+  if (!eigen_threadpool_) return;  // Can't resize user provided pool.
+
+  eigen_threadpool_.reset(new Eigen::ThreadPoolTempl<EigenEnvironment>(
+      num_threads, low_latency_hint_,
+      EigenEnvironment(env_, thread_options_, "tf_" + name_)));
+  underlying_threadpool_ = eigen_threadpool_.get();
+  threadpool_device_.reset(new Eigen::ThreadPoolDevice(
+      underlying_threadpool_, num_threads, allocator_));
 }
 
 Eigen::ThreadPoolInterface* ThreadPool::AsEigenThreadPool() const {

--- a/third_party/xla/xla/tsl/platform/threadpool.h
+++ b/third_party/xla/xla/tsl/platform/threadpool.h
@@ -152,6 +152,11 @@ class ThreadPool {
 
   void ScheduleWithHint(std::function<void()> fn, int start, int limit);
 
+  // Dynamically resizes the thread pool. Only works if the pool
+  // was created internally and not with a user provided
+  // ThreadPoolInterface. Pending work is not waited on.
+  void Resize(int num_threads);
+
   // Returns the number of shards used by ParallelForFixedBlockSizeScheduling
   // with these parameters.
   int NumShardsUsedByFixedBlockSizeScheduling(int64_t total,
@@ -248,6 +253,13 @@ class ThreadPool {
   // user_threadpool is not in the constructor.
   std::unique_ptr<Eigen::ThreadPoolTempl<EigenEnvironment>> eigen_threadpool_;
   std::unique_ptr<Eigen::ThreadPoolDevice> threadpool_device_;
+
+  // Saved parameters needed to recreate the underlying pool on resize.
+  Env* env_ = nullptr;
+  ThreadOptions thread_options_;
+  std::string name_;
+  bool low_latency_hint_ = true;
+  Eigen::Allocator* allocator_ = nullptr;
 
   ThreadPool(const ThreadPool&) = delete;
   void operator=(const ThreadPool&) = delete;


### PR DESCRIPTION
## Summary
- add a `Resize` API for `tsl::thread::ThreadPool`
- keep constructor parameters so we can rebuild the Eigen pool

## Testing
- `clang-format -i third_party/xla/xla/tsl/platform/threadpool.h third_party/xla/xla/tsl/platform/threadpool.cc`
- `python3 -V`

------
https://chatgpt.com/codex/tasks/task_e_6873451702fc832499178c0cddced949